### PR TITLE
Update CDEPS to latest ESCOMP/CDEPS master and add variables for optional flux calculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,4 +99,4 @@ foreach(DEPS streams dshr cdeps_share FoX_dom FoX_wxml FoX_sax FoX_common FoX_ut
           COMPONENT Library)
   install(EXPORT      ${DEPS} 
           DESTINATION lib/cmake)
-endforeach(COMP)
+endforeach(DEPS)

--- a/cime_config/testdefs/testlist_cdeps.xml
+++ b/cime_config/testdefs/testlist_cdeps.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <test compset="2000_DATM%QIA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%QIA_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -9,7 +9,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%CRUv7_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%CRUv7_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -17,7 +17,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="HIST_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="HIST_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -25,7 +25,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="1850_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="1850_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -33,7 +33,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="2010_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -41,7 +41,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="SSP585_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="SSP585_DATM%GSWP3v1_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>
@@ -49,7 +49,7 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_DATM%NLDAS2_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_musgs" name="SMS_Vnuopc_Ld5">
+  <test compset="2000_DATM%NLDAS2_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP" grid="f10_f10_mg37" name="SMS_Vnuopc_Ld5">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cdeps"/>
     </machines>

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -64,11 +64,6 @@ module atm_comp_nuopc
   use datm_datamode_era5_mod    , only : datm_datamode_era5_advance
   use datm_datamode_era5_mod    , only : datm_datamode_era5_restart_write
   use datm_datamode_era5_mod    , only : datm_datamode_era5_restart_read
-  use datm_datamode_cfsr_mod    , only : datm_datamode_cfsr_advertise
-  use datm_datamode_cfsr_mod    , only : datm_datamode_cfsr_init_pointers
-  use datm_datamode_cfsr_mod    , only : datm_datamode_cfsr_advance
-  use datm_datamode_cfsr_mod    , only : datm_datamode_cfsr_restart_write
-  use datm_datamode_cfsr_mod    , only : datm_datamode_cfsr_restart_read
 
   use datm_datamode_cfsr_mod    , only : datm_datamode_cfsr_advertise
   use datm_datamode_cfsr_mod    , only : datm_datamode_cfsr_init_pointers

--- a/datm/cime_config/buildnml
+++ b/datm/cime_config/buildnml
@@ -74,8 +74,10 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     config['datm_co2_tseries'] = datm_co2_tseries
     config['datm_presaero'] = datm_presaero
     config['cime_model'] = get_model()
-    config['scol_mode'] = 'true' if case.get_value('PTS_MODE') else 'false'
-    config['create_mesh'] = 'true' if case.get_value("ATM_DOMAIN_MESH") == 'create_mesh' else 'false'
+    if case.get_value('PTS_MODE'):
+        config['mode'] = 'single_column'
+    else:
+        config['mode'] = case.get_value("ATM_DOMAIN_MESH")
 
     nmlgen.init_defaults(infile, config)
 

--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -159,46 +159,7 @@
     <desc>case name used to determine stream filenames when DATM_MODE is CPLHIST</desc>
   </entry>
 
-  <entry id="DATM_CPLHIST_YR_ALIGN">
-    <type>integer</type>
-    <valid_values></valid_values>
-    <default_value>-999</default_value>
-    <group>run_component_datm</group>
-    <file>env_run.xml</file>
-    <desc>
-      Simulation year corresponding to DATM_CPLHIST_YR_START (only used
-      when DATM_MODE is CPLHIST). A common usage is to set this to
-      RUN_STARTDATE. With this setting, the forcing in the first year of
-      the run will be the forcing of year DATM_CPLHIST_YR_START. Another
-      use case is to align the calendar of transient forcing with the
-      model calendar. For example, setting
-      DATM_CPLHIST_YR_ALIGN=DATM_CPLHIST_YR_START will lead to the
-      forcing calendar being the same as the model calendar. The forcing
-      for a given model year would be the forcing of the same year. This
-      would be appropriate in transient runs where the model calendar is
-      setup to span the same year range as the forcing data.
-    </desc>
-  </entry>
-
-  <entry id="DATM_CPLHIST_YR_START">
-    <type>integer</type>
-    <valid_values></valid_values>
-    <default_value>-999</default_value>
-    <group>run_component_datm</group>
-    <file>env_run.xml</file>
-    <desc>starting year to loop data over (only used when DATM_MODE is CPLHIST)</desc>
-  </entry>
-
-  <entry id="DATM_CPLHIST_YR_END">
-    <type>integer</type>
-    <valid_values></valid_values>
-    <default_value>-999</default_value>
-    <group>run_component_datm</group>
-    <file>env_run.xml</file>
-    <desc>ending year to loop data over (only used when DATM_MODE is CPLHIST)</desc>
-  </entry>
-
-  <entry id="DATM_CLMNCEP_YR_ALIGN">
+  <entry id="DATM_YR_ALIGN">
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>1</default_value>
@@ -209,26 +170,38 @@
       <value compset="HIST.*_DATM%QIA">1895</value>
       <value compset="HIST.*_DATM%CRU">1901</value>
       <value compset="HIST.*_DATM%GSW">1901</value>
-      <value compset="HIST.*_DATM%NLDAS2">$DATM_CLMNCEP_YR_START</value>
+      <value compset="HIST.*_DATM%NLDAS2">$DATM_YR_START</value>
       <value compset="20TR.*_DATM%QIA">1895</value>
       <value compset="20TR.*_DATM%CRU">1901</value>
       <value compset="20TR.*_DATM%GSW">1901</value>
-      <value compset="SSP.*_DATM%QIA">$DATM_CLMNCEP_YR_START</value>
-      <value compset="SSP.*_DATM%CRU">$DATM_CLMNCEP_YR_START</value>
-      <value compset="SSP.*_DATM%GSW">$DATM_CLMNCEP_YR_START</value>
+      <value compset="SSP.*_DATM%QIA">$DATM_YR_START</value>
+      <value compset="SSP.*_DATM%CRU">$DATM_YR_START</value>
+      <value compset="SSP.*_DATM%GSW">$DATM_YR_START</value>
       <value compset="1850.*_DATM%CRU">1</value>
       <value compset="1850.*_DATM%GSW">1</value>
-      <value compset="2000.*_DATM">$DATM_CLMNCEP_YR_START</value>
-      <value compset="2003.*_DATM">$DATM_CLMNCEP_YR_START</value>
-      <value compset="2010.*_DATM">$DATM_CLMNCEP_YR_START</value>
-      <value compset="4804.*_DATM">$DATM_CLMNCEP_YR_START</value>
+      <value compset="2000.*_DATM">$DATM_YR_START</value>
+      <value compset="2003.*_DATM">$DATM_YR_START</value>
+      <value compset="2010.*_DATM">$DATM_YR_START</value>
+      <value compset="4804.*_DATM">$DATM_YR_START</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
-    <desc>year align</desc>
+    <desc>
+      Simulation year corresponding to DATM_YR_START. A common usage
+      is to set this to RUN_STARTDATE. With this setting, the forcing
+      in the first year of the run will be the forcing of year
+      DATM_YR_START. Another use case is to align the calendar
+      of transient forcing with the model calendar. For example,
+      setting DATM_YR_ALIGN=DATM_YR_START will lead to
+      the forcing calendar being the same as the model calendar. The
+      forcing for a given model year would be the forcing of the same
+      year. This would be appropriate in transient runs where the
+      model calendar is setup to span the same year range as the
+      forcing data.
+    </desc>
   </entry>
 
-  <entry id="DATM_CLMNCEP_YR_START">
+  <entry id="DATM_YR_START">
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>2004</default_value>
@@ -270,7 +243,7 @@
     <desc>starting year to loop data over</desc>
   </entry>
 
-  <entry id="DATM_CLMNCEP_YR_END">
+  <entry id="DATM_YR_END">
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>2004</default_value>

--- a/datm/cime_config/namelist_definition_datm.xml
+++ b/datm/cime_config/namelist_definition_datm.xml
@@ -133,8 +133,8 @@
     </desc>
     <values>
       <value>$ATM_DOMAIN_MESH</value>
-      <value scol_mode='true'>null</value>
-      <value create_mesh='true'>null</value>
+      <value mode='scol'>null</value>
+      <value mode='create_mesh'>null</value>
     </values>
   </entry>
 
@@ -148,8 +148,8 @@
     </desc>
     <values>
       <value>$ATM_DOMAIN_MESH</value>
-      <value scol_mode='true'>$ATM_DOMAIN_PATH/$ATM_DOMAIN_FILE</value>
-      <value create_mesh='true'>$ATM_DOMAIN_PATH/$ATM_DOMAIN_FILE</value>
+      <value mode='scol'>$ATM_DOMAIN_PATH/$ATM_DOMAIN_FILE</value>
+      <value mode='create_mesh'>$ATM_DOMAIN_PATH/$ATM_DOMAIN_FILE</value>
     </values>
   </entry>
 
@@ -163,8 +163,8 @@
     </desc>
     <values>
       <value>null</value>
-      <value scol_mode='true'>$ATM_DOMAIN_PATH/$ATM_DOMAIN_FILE</value>
-      <value create_mesh='true'>$ATM_DOMAIN_PATH/$ATM_DOMAIN_FILE</value>
+      <value mode='scol'>$ATM_DOMAIN_PATH/$ATM_DOMAIN_FILE</value>
+      <value mode='create_mesh'>$ATM_DOMAIN_PATH/$ATM_DOMAIN_FILE</value>
     </values>
   </entry>
 

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -214,9 +214,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>coszen</tintalgo>
@@ -246,9 +246,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>nearest</tintalgo>
@@ -282,9 +282,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>linear</tintalgo>
@@ -317,9 +317,9 @@
       <mapalgo>bilinear</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>coszen</tintalgo>
@@ -348,9 +348,9 @@
       <mapalgo>bilinear</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>nearest</tintalgo>
@@ -383,9 +383,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>linear</tintalgo>
@@ -419,9 +419,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>coszen</tintalgo>
@@ -451,9 +451,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>nearest</tintalgo>
@@ -486,9 +486,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>linear</tintalgo>
@@ -522,7 +522,7 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
     <stream_year_first>2000</stream_year_first>
     <stream_year_last>2004</stream_year_last>
     <stream_offset>0</stream_offset>
@@ -554,7 +554,7 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
     <stream_year_first>2000</stream_year_first>
     <stream_year_last>2004</stream_year_last>
     <stream_offset>0</stream_offset>
@@ -589,7 +589,7 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
     <stream_year_first>2000</stream_year_first>
     <stream_year_last>2004</stream_year_last>
     <stream_offset>0</stream_offset>
@@ -624,9 +624,9 @@
       <mapalgo>redist</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>coszen</tintalgo>
@@ -655,9 +655,9 @@
       <mapalgo>redist</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>nearest</tintalgo>
@@ -690,9 +690,9 @@
       <mapalgo>redist</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CLMNCEP_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CLMNCEP_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>linear</tintalgo>
@@ -734,7 +734,7 @@
       <mapalgo>none</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
     <stream_year_first>1993</stream_year_first>
     <stream_year_last >1993</stream_year_last>
     <stream_offset>0</stream_offset>
@@ -774,7 +774,7 @@
       <mapalgo>none</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
     <stream_year_first>1992</stream_year_first>
     <stream_year_last >1992</stream_year_last>
     <stream_offset>0</stream_offset>
@@ -829,7 +829,7 @@
       <mapalgo>none</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CLMNCEP_YR_ALIGN</stream_year_align>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
     <stream_year_first>0001</stream_year_first>
     <stream_year_last >0002</stream_year_last>
     <stream_offset>0</stream_offset>
@@ -3427,7 +3427,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
    </stream_datafiles>
     <stream_datavars>
       <var>a2x3h_Sa_topo  Sa_topo</var>
@@ -3438,9 +3438,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CPLHIST_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CPLHIST_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CPLHIST_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>nearest</tintalgo>
@@ -3458,7 +3458,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1d.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1d.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>a2x1d_Faxa_bcphiwet  Faxa_bcphiwet</var>
@@ -3482,9 +3482,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CPLHIST_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CPLHIST_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CPLHIST_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>0</stream_offset>
     <stream_tintalgo>
       <tintalgo>nearest</tintalgo>
@@ -3503,7 +3503,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1hi.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1hi.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>a2x1hi_Faxa_swndr Faxa_swndr</var>
@@ -3517,9 +3517,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CPLHIST_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CPLHIST_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CPLHIST_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>2700</stream_offset>
     <stream_tintalgo>
       <tintalgo>nearest</tintalgo>
@@ -3538,7 +3538,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>a2x3h_Faxa_rainc Faxa_rainc</var>
@@ -3553,9 +3553,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CPLHIST_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CPLHIST_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CPLHIST_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>900</stream_offset>
     <stream_tintalgo>
       <tintalgo>nearest</tintalgo>
@@ -3574,7 +3574,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>a2x3h_Sa_z       Sa_z</var>
@@ -3593,9 +3593,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CPLHIST_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CPLHIST_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CPLHIST_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>900</stream_offset>
     <stream_tintalgo>
       <tintalgo>linear</tintalgo>
@@ -3614,7 +3614,7 @@
       <meshfile>$ATM_DOMAIN_MESH</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file first_year="$DATM_CPLHIST_YR_START" last_year="$DATM_CPLHIST_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1h.%ym.nc</file>
+      <file first_year="$DATM_YR_START" last_year="$DATM_YR_END">$DATM_CPLHIST_DIR/$DATM_CPLHIST_CASE.cpl.ha2x1h.%ym.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <var>a2x1h_Sa_u  Sa_u</var>
@@ -3626,9 +3626,9 @@
       <mapalgo model_grid="1x1">nn</mapalgo>
     </stream_mapalgo>
     <stream_vectors>null</stream_vectors>
-    <stream_year_align>$DATM_CPLHIST_YR_ALIGN</stream_year_align>
-    <stream_year_first>$DATM_CPLHIST_YR_START</stream_year_first>
-    <stream_year_last>$DATM_CPLHIST_YR_END</stream_year_last>
+    <stream_year_align>$DATM_YR_ALIGN</stream_year_align>
+    <stream_year_first>$DATM_YR_START</stream_year_first>
+    <stream_year_last>$DATM_YR_END</stream_year_last>
     <stream_offset>900</stream_offset>
     <stream_tintalgo>
       <tintalgo>linear</tintalgo>

--- a/datm/datm_datamode_cfsr_mod.F90
+++ b/datm/datm_datamode_cfsr_mod.F90
@@ -21,6 +21,7 @@ module datm_datamode_cfsr_mod
   public  :: datm_datamode_cfsr_advance
   public  :: datm_datamode_cfsr_restart_write
   public  :: datm_datamode_cfsr_restart_read
+!  private :: datm_eSat  ! determine saturation vapor pressure
 
   ! export state data
   real(r8), pointer :: Sa_z(:)              => null()
@@ -29,9 +30,14 @@ module datm_datamode_cfsr_mod
   real(r8), pointer :: Sa_tbot(:)           => null()
   real(r8), pointer :: Sa_shum(:)           => null()
   real(r8), pointer :: Sa_pbot(:)           => null()
+  real(r8), pointer :: Sa_u10m(:)           => null()
+  real(r8), pointer :: Sa_v10m(:)           => null()
+  real(r8), pointer :: Sa_t2m(:)           => null()
+  real(r8), pointer :: Sa_q2m(:)           => null()
+  real(r8), pointer :: Sa_pslv(:)           => null()
   real(r8), pointer :: Faxa_lwdn(:)         => null()
   real(r8), pointer :: Faxa_rain(:)         => null()
-  real(r8), pointer :: Faxa_snow(:)         => null()
+  real(r8), pointer :: Faxa_snow(:)        => null()
   real(r8), pointer :: Faxa_swndr(:)        => null()
   real(r8), pointer :: Faxa_swndf(:)        => null()
   real(r8), pointer :: Faxa_swvdr(:)        => null()
@@ -78,6 +84,11 @@ contains
     call dshr_fldList_add(fldsExport, 'Sa_tbot'    )
     call dshr_fldList_add(fldsExport, 'Sa_pbot'    )
     call dshr_fldList_add(fldsExport, 'Sa_shum'    )
+    call dshr_fldList_add(fldsExport, 'Sa_u10m'    )
+    call dshr_fldList_add(fldsExport, 'Sa_v10m'    )
+    call dshr_fldList_add(fldsExport, 'Sa_t2m'    )
+    call dshr_fldList_add(fldsExport, 'Sa_q2m'    )
+    call dshr_fldList_add(fldsExport, 'Sa_pslv'    )
     call dshr_fldList_add(fldsExport, 'Faxa_rain'  )
     call dshr_fldList_add(fldsExport, 'Faxa_snow' )
     call dshr_fldList_add(fldsExport, 'Faxa_swndr' )
@@ -113,6 +124,7 @@ contains
     ! initialize pointers for module level stream arrays
     call shr_strdata_get_stream_pointer( sdat, 'Sa_mask'   , strm_mask , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
     ! get export state pointers
     call dshr_state_getfldptr(exportState, 'Sa_z'       , fldptr1=Sa_z       , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -126,9 +138,19 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_shum'    , fldptr1=Sa_shum    , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_u10m'    , fldptr1=Sa_u10m    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_v10m'    , fldptr1=Sa_v10m    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_t2m'    , fldptr1=Sa_t2m    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_q2m'    , fldptr1=Sa_q2m    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_pslv'    , fldptr1=Sa_pslv    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_rain'  , fldptr1=Faxa_rain  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call dshr_state_getfldptr(exportState, 'Faxa_snow'  , fldptr1=Faxa_snow  , rc=rc)
+    call dshr_state_getfldptr(exportState, 'Faxa_snow' , fldptr1=Faxa_snow, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_swvdr' , fldptr1=Faxa_swvdr , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -187,6 +209,13 @@ contains
     end if
 
     do n = 1, lsize
+       !--- bottom layer height ---
+!       Sa_z(n) = 10.0_r8
+
+       !--- calculate wind speed ---
+!       if (associated(Sa_wspd)) then
+!         Sa_wspd(n) = sqrt(Sa_u(n)*Sa_u(n)+Sa_v(n)*Sa_v(n)) 
+!       end if
 
        !--- temperature ---
        if (tbotmax < 50.0_r8) Sa_tbot(n) = Sa_tbot(n) + tkFrz
@@ -196,8 +225,43 @@ contains
     end do
 
     !----------------------------------------------------------
-    ! unit conversions (temporal resolution is 6-hourly)
+    ! unit conversions (temporal resolution is hourly)
     !----------------------------------------------------------
+
+    ! convert J/m^2 to W/m^2
+    !Faxa_lwdn(:) = Faxa_lwdn(:)/3600.0_r8
+!    Faxa_lwdn(:) = Faxa_lwdn(:)/21600.0_r8
+!    if (associated(Faxa_lwnet)) then
+!      Faxa_lwnet(:) = Faxa_lwnet(:)/3600.0_r8
+!    end if
+!    Faxa_swdn(:) = Faxa_swdn(:)/3600.0_r8
+!    Faxa_swdn(:) = Faxa_swdn(:)/21600.0_r8
+    !Faxa_swvdr(:) = Faxa_swvdr(:)/3600.0_r8
+    !Faxa_swndr(:) = Faxa_swndr(:)/3600.0_r8
+    !Faxa_swvdf(:) = Faxa_swvdf(:)/3600.0_r8
+    !Faxa_swndf(:) = Faxa_swndf(:)/3600.0_r8
+!    Faxa_swvdr(:) = Faxa_swvdr(:)/21600.0_r8
+!    Faxa_swndr(:) = Faxa_swndr(:)/21600.0_r8
+!    Faxa_swvdf(:) = Faxa_swvdf(:)/21600.0_r8
+!    Faxa_swndf(:) = Faxa_swndf(:)/21600.0_r8
+!    Faxa_swnet(:) = Faxa_swnet(:)/3600.0_r8
+!    Faxa_sen(:) = Faxa_sen(:)/3600.0_r8
+!    Faxa_lat(:) = Faxa_lat(:)/3600.0_r8
+
+    ! convert m to kg/m^2/s
+    !Faxa_rain(:) = Faxa_rain(:)/3600.0_r8*rhofw
+!    Faxa_rain(:) = Faxa_rain(:)/21600.0_r8*rhofw
+!    Faxa_rainc(:) = Faxa_rainc(:)/3600.0_r8*rhofw
+!    Faxa_rainl(:) = Faxa_rainl(:)/3600.0_r8*rhofw
+!    Faxa_snowc(:) = Faxa_snowc(:)/3600.0_r8*rhofw
+    !Faxa_snow(:) = Faxa_snow(:)/3600.0_r8*rhofw
+!    Faxa_snow(:) = Faxa_snow(:)/21600.0_r8*rhofw
+
+    ! convert N/m^2 s to N/m^2
+!    Faxa_taux(:) = Faxa_taux(:)/3600.0_r8
+!    Faxa_tauy(:) = Faxa_tauy(:)/3600.0_r8
+!    Faxa_taux(:) = Faxa_taux(:)/21600.0_r8
+!    Faxa_tauy(:) = Faxa_tauy(:)/21600.0_r8
 
   end subroutine datm_datamode_cfsr_advance
 

--- a/dice/cime_config/buildnml
+++ b/dice/cime_config/buildnml
@@ -63,10 +63,15 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     config = {}
     config['ice_grid'] = ice_grid
     config['dice_mode'] = dice_mode
-    config['scol_mode'] = 'true' if case.get_value('PTS_MODE') else 'false'
-    config['create_mesh'] = 'true' if case.get_value("ICE_DOMAIN_MESH") == 'create_mesh' else 'false'
-    scol_mode = True if case.get_value('PTS_MODE') else False
-    config['set_model_maskfile'] = 'true' if scol_mode or (ice_nx==atm_nx and ice_ny==atm_ny) else 'false'
+    config['set_model_maskfile'] = 'false'
+    if case.get_value('PTS_MODE'):
+        config['mode'] = 'single_column'
+        config['set_model_maskfile'] = 'true'
+    else:
+        config['mode'] = case.get_value("ICE_DOMAIN_MESH")
+
+    if (ice_nx==atm_nx and ice_ny==atm_ny):
+        config['set_model_maskfile'] = 'true'
 
     # Initialize nmlgen
     nmlgen.init_defaults(infile, config)

--- a/dice/cime_config/namelist_definition_dice.xml
+++ b/dice/cime_config/namelist_definition_dice.xml
@@ -54,8 +54,8 @@
     <desc>file specifying model mesh</desc>
     <values>
       <value>$ICE_DOMAIN_MESH</value>
-      <value scol_mode='true'>null</value>
-      <value create_mesh='true'>null</value>
+      <value mode='scol'>null</value>
+      <value mode='create_mesh'>null</value>
     </values>
   </entry>
 
@@ -68,10 +68,7 @@
       file specifying model mask if not obtained from input model mesh
     </desc>
     <values>
-      <value>$ICE_DOMAIN_MESH</value>
-      <value scol_mode='true'>$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
-      <value create_mesh='true'>$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
-      <value set_model_maskfile='true'>$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
+      <value>$MASK_MESH</value>
     </values>
   </entry>
 
@@ -83,8 +80,8 @@
     <desc>file specifying if model mesh is to be created at runtime</desc>
     <values>
       <value>null</value>
-      <value scol_mode='true'>$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
-      <value create_mesh='true'>$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
+      <value mode='scol'>$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
+      <value mode='create_mesh'>$ICE_DOMAIN_PATH/$ICE_DOMAIN_FILE</value>
     </values>
   </entry>
 

--- a/dlnd/cime_config/buildnml
+++ b/dlnd/cime_config/buildnml
@@ -62,9 +62,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     config['dlnd_mode'] = dlnd_mode
     config['create_mesh'] = 'true' if case.get_value("LND_DOMAIN_MESH") == 'create_mesh' else 'false'
 
-    # Do not allow single column mode for drof
-    scol_mode = True if case.get_value('PTS_MODE') else False
-    expect(not scol_mode, 
+    # Do not allow single column mode for dlnd
+    expect(not case.get_value('PTS_MODE'),
            "for DLND, single column mode is not allowed")
 
     # Initialize nmlgen

--- a/doc/source/streams.rst
+++ b/doc/source/streams.rst
@@ -219,15 +219,15 @@ where:
   over the forcing data for 1901-1920, and then run the model for years
   1901-2010 using the forcing data from 1901-2010. To do this, initially set::
 
-    ./xmlchange DATM_CLMNCEP_YR_ALIGN=1901
-    ./xmlchange DATM_CLMNCEP_YR_START=1901
-    ./xmlchange DATM_CLMNCEP_YR_END=1920
+    ./xmlchange DATM_YR_ALIGN=1901
+    ./xmlchange DATM_YR_START=1901
+    ./xmlchange DATM_YR_END=1920
 
   When the model has completed year 1900, set::
 
-    ./xmlchange DATM_CLMNCEP_YR_ALIGN=1901
-    ./xmlchange DATM_CLMNCEP_YR_START=1901
-    ./xmlchange DATM_CLMNCEP_YR_END=2010
+    ./xmlchange DATM_YR_ALIGN=1901
+    ./xmlchange DATM_YR_START=1901
+    ./xmlchange DATM_YR_END=2010
 
   With this setup, the correlation between model run year and forcing year
   looks like this::
@@ -235,7 +235,7 @@ where:
     RUN   Year : 1850 ... 1860 1861 ... 1870 ... 1880 1881 ... 1890 ... 1900 1901 ... 2010
     FORCE Year : 1910 ... 1920 1901 ... 1910 ... 1920 1901 ... 1910 ... 1920 1901 ... 2010
 
-  Setting ``DATM_CLMNCEP_YR_ALIGN`` to 1901 tells the code that you want
+  Setting ``DATM_YR_ALIGN`` to 1901 tells the code that you want
   to align model year 1901 with forcing data year 1901, and then it
   calculates what the forcing year should be if the model starts in year 1850.
 

--- a/docn/cime_config/buildnml
+++ b/docn/cime_config/buildnml
@@ -69,7 +69,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     config['docn_mode'] = docn_mode
     config['create_mesh'] = 'true' if case.get_value("OCN_DOMAIN_MESH") == 'create_mesh' else 'false'
     config['aqua_planet'] = 'true' if 'aquap' in docn_mode else 'false'
-    scol_mode = True if case.get_value('PTS_MODE') else False
 
     nmlgen.init_defaults(infile, config)
 

--- a/docn/cime_config/namelist_definition_docn.xml
+++ b/docn/cime_config/namelist_definition_docn.xml
@@ -119,8 +119,8 @@
     </desc>
     <values>
       <value>$OCN_DOMAIN_MESH</value>
-      <value scol_mode='true'>null</value>
-      <value create_mesh='true'>null</value>
+      <value mode='scol'>null</value>
+      <value mode='create_mesh'>null</value>
     </values>
   </entry>
 
@@ -148,8 +148,8 @@
     </desc>
     <values>
       <value>null</value>
-      <value scol_mode='true'>$OCN_DOMAIN_PATH/$OCN_DOMAIN_FILE</value>
-      <value create_mesh='true'>$OCN_DOMAIN_PATH/$OCN_DOMAIN_FILE</value>
+      <value mode='scol'>$OCN_DOMAIN_PATH/$OCN_DOMAIN_FILE</value>
+      <value mode='create_mesh'>$OCN_DOMAIN_PATH/$OCN_DOMAIN_FILE</value>
     </values>
   </entry>
 

--- a/drof/cime_config/buildnml
+++ b/drof/cime_config/buildnml
@@ -63,8 +63,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     config['create_mesh'] = 'true' if case.get_value("ROF_DOMAIN_MESH") == 'create_mesh' else 'false'
 
     # Do not allow single column mode for drof
-    scol_mode = True if case.get_value('PTS_MODE') else False
-    expect(not scol_mode, 
+    expect(not case.get_value('PTS_MODE'),
            "for, DROF single column mode is not allowed")
 
     # Initialize nmlgen

--- a/dwav/cime_config/buildnml
+++ b/dwav/cime_config/buildnml
@@ -61,8 +61,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     config['dwav_mode'] = dwav_mode
 
     # do not allow single column mode for dwav
-    scol_mode = True if case.get_value('PTS_MODE') else False
-    expect(not scol_mode, 
+    expect(not case.get_value('PTS_MODE'),
            "for, DWAV single column mode is not allowed")
 
     # Initialize nmlgen


### PR DESCRIPTION
### Description of changes

Update CDEPS to ESCOMP/CDEPS master (02/04/2021 version).
Update datm/datm_datamode_cfsr_mod.F90 to include additional variables for optional flux calculation.

### Specific notes

CDEPS Issues Fixed: #7 

Testing performed:
   - machines and compilers: Orion, Intel
   - details:  Code can be compiled successfully using ufs-weather-model (https://github.com/binli2337/ufs-weather-model/tree/feature/add_cdeps).
