### PR TITLE
Revise the GFS_HAFS data mode

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -359,7 +359,7 @@ contains
          trim(datamode) == 'GEFS'         .or. &
          trim(datamode) == 'CFSR'         .or. &
          trim(datamode) == 'GFS'          .or. &
-         trim(datamode(1:8)) == 'GFS_HAFS'     .or. &
+         datamode(1:8)  == 'GFS_HAFS'     .or. &
          trim(datamode) == 'ERA5') then
     else
        call shr_sys_abort(' ERROR illegal datm datamode = '//trim(datamode))

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -359,7 +359,7 @@ contains
          trim(datamode) == 'GEFS'         .or. &
          trim(datamode) == 'CFSR'         .or. &
          trim(datamode) == 'GFS'          .or. &
-         trim(datamode) == 'GFS_HAFS'     .or. &
+         trim(datamode(1:8)) == 'GFS_HAFS'     .or. &
          trim(datamode) == 'ERA5') then
     else
        call shr_sys_abort(' ERROR illegal datm datamode = '//trim(datamode))
@@ -396,7 +396,10 @@ contains
        call datm_datamode_gfs_advertise(exportState, fldsExport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('GFS_HAFS')
-       call datm_datamode_gfs_hafs_advertise(exportState, fldsExport, flds_scalar_name, rc)
+       call datm_datamode_gfs_hafs_advertise(exportState, fldsExport, flds_scalar_name, datamode, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    case ('GFS_HAFS_WW3')
+       call datm_datamode_gfs_hafs_advertise(exportState, fldsExport, flds_scalar_name, datamode, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end select
 
@@ -645,7 +648,10 @@ contains
           call datm_datamode_gfs_init_pointers(exportState, sdat, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case('GFS_HAFS')
-          call datm_datamode_gfs_hafs_init_pointers(exportState, sdat, rc)
+          call datm_datamode_gfs_hafs_init_pointers(exportState, sdat, datamode, rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       case('GFS_HAFS_WW3')
+          call datm_datamode_gfs_hafs_init_pointers(exportState, sdat, datamode, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end select
 
@@ -669,6 +675,8 @@ contains
           case('GFS')
              call datm_datamode_gfs_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat)
           case('GFS_HAFS')
+             call datm_datamode_gfs_hafs_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat)
+          case('GFS_HAFS_WW3')
              call datm_datamode_gfs_hafs_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat)
           end select
        end if
@@ -732,6 +740,10 @@ contains
        call datm_datamode_gfs_hafs_advance(exportstate, mainproc, logunit, mpicom, target_ymd, &
             target_tod, sdat%model_calendar, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    case('GFS_HAFS_WW3')
+       call datm_datamode_gfs_hafs_advance(exportstate, mainproc, logunit, mpicom, target_ymd, &
+            target_tod, sdat%model_calendar, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end select
 
     ! Write restarts if needed
@@ -765,6 +777,10 @@ contains
                logunit, my_task, sdat)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case('GFS_HAFS')
+          call datm_datamode_gfs_hafs_restart_write(case_name, inst_suffix, target_ymd, target_tod, &
+               logunit, my_task, sdat)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       case('GFS_HAFS_WW3')
           call datm_datamode_gfs_hafs_restart_write(case_name, inst_suffix, target_ymd, target_tod, &
                logunit, my_task, sdat)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/datm/datm_datamode_gfs_hafs_mod.F90
+++ b/datm/datm_datamode_gfs_hafs_mod.F90
@@ -55,12 +55,13 @@ contains
 !===============================================================================
 
   subroutine datm_datamode_gfs_hafs_advertise(exportState, fldsexport, &
-       flds_scalar_name, rc)
+       flds_scalar_name, datamode, rc)
 
     ! input/output variables
     type(esmf_State)   , intent(inout) :: exportState
     type(fldlist_type) , pointer       :: fldsexport
     character(len=*)   , intent(in)    :: flds_scalar_name
+    character(len=*)   , intent(in)    :: datamode
     integer            , intent(out)   :: rc
 
     ! local variables
@@ -71,8 +72,6 @@ contains
 
     call dshr_fldList_add(fldsExport, trim(flds_scalar_name))
     call dshr_fldList_add(fldsExport, 'Sd_pslv'    )
-    call dshr_fldList_add(fldsExport, 'Sd_u10m'    )
-    call dshr_fldList_add(fldsExport, 'Sd_v10m'    )
     call dshr_fldList_add(fldsExport, 'Faxd_swvdr'  )
     call dshr_fldList_add(fldsExport, 'Faxd_swvdf'  )
     call dshr_fldList_add(fldsExport, 'Faxd_swndr' )
@@ -83,6 +82,10 @@ contains
     call dshr_fldList_add(fldsExport, 'Faxd_sen'    )
     call dshr_fldList_add(fldsExport, 'Faxd_lat'    )
     call dshr_fldList_add(fldsExport, 'Faxd_rain'   )
+    if(trim(datamode) == 'GFS_HAFS_WW3') then
+       call dshr_fldList_add(fldsExport, 'Sd_u10m'    )
+       call dshr_fldList_add(fldsExport, 'Sd_v10m'    )
+    end if
 
     fldlist => fldsExport ! the head of the linked list
     do while (associated(fldlist))
@@ -95,11 +98,12 @@ contains
   end subroutine datm_datamode_gfs_hafs_advertise
 
   !===============================================================================
-  subroutine datm_datamode_gfs_hafs_init_pointers(exportState, sdat, rc)
+  subroutine datm_datamode_gfs_hafs_init_pointers(exportState, sdat, datamode, rc)
 
     ! input/output variables
     type(ESMF_State)       , intent(inout) :: exportState
     type(shr_strdata_type) , intent(in)    :: sdat
+    character(len=*)       , intent(in)    :: datamode
     integer                , intent(out)   :: rc
 
     ! local variables
@@ -114,11 +118,13 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! get export state pointers
+    if(trim(datamode) == 'GFS_HAFS_WW3') then
+       call dshr_state_getfldptr(exportState, 'Sd_u10m'    , fldptr1=Sd_u10m    , rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call dshr_state_getfldptr(exportState, 'Sd_v10m'    , fldptr1=Sd_v10m    , rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
     call dshr_state_getfldptr(exportState, 'Sd_pslv'    , fldptr1=Sd_pslv    , rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call dshr_state_getfldptr(exportState, 'Sd_u10m'    , fldptr1=Sd_u10m    , rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call dshr_state_getfldptr(exportState, 'Sd_v10m'    , fldptr1=Sd_v10m    , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxd_swvdr' , fldptr1=Faxd_swvdr , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return


### PR DESCRIPTION
### Description of changes
The GFS_HAFS datamode will be updated as follows:

1. The GFS_HAFS datamode will be used for the HAFS_MOM6 system. The wind fields will not be included in the export state.
 2. The GFS_HAFS_WW3 datamode will be used for the HAFS_MOM6_WW3 system. The wind fields will be include in the export state.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed #56 

Are there dependencies on other component PRs (if so list): no

Are changes expected to change answers (bfb, different to roundoff, more substantial): no

Baseline results can be reproduced for all the hafs tests.

Any User Interface Changes (namelist or namelist defaults changes): no


