### PR TITLE
Create cplhist mode for dice

### DIFF
--- a/dice/CMakeLists.txt
+++ b/dice/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(dice Fortran)
 set(SRCFILES ice_comp_nuopc.F90
              dice_datamode_ssmi_mod.F90
+             dice_datamode_cplhist_mod.F90
 	     dice_flux_atmice_mod.F90)
 
 foreach(FILE ${SRCFILES})

--- a/dice/dice_datamode_cplhist_mod.F90
+++ b/dice/dice_datamode_cplhist_mod.F90
@@ -3,7 +3,7 @@ module dice_datamode_cplhist_mod
   use ESMF             , only : ESMF_State, ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_SUCCESS
   use NUOPC            , only : NUOPC_Advertise
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  !use shr_const_mod    , only : shr_const_TkFrz, shr_const_pi, shr_const_ocn_ref_sal
+  use shr_const_mod    , only : shr_const_TkFrzsw
   use shr_sys_mod      , only : shr_sys_abort
   use dshr_methods_mod , only : dshr_state_getfldptr, dshr_fldbun_getfldptr, chkerr
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
@@ -151,7 +151,9 @@ contains
 
     rc = ESMF_SUCCESS
 
-    ! For now - do nothing special
+    !Unit conversions, calculations,....
+    !Where aice=0, Si_t=0K (as missing value). Interpolation in time between ice that comes or goes then has issues
+    where(Si_t .LT. 10) Si_t = shr_const_TkFrzsw
 
   end subroutine dice_datamode_cplhist_advance
 

--- a/dice/dice_datamode_cplhist_mod.F90
+++ b/dice/dice_datamode_cplhist_mod.F90
@@ -108,7 +108,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Si_imask' , fldptr1=Si_imask , rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-    call dshr_state_getfldptr(exportState, 'Faii_taux'     , fldptr1=Faii_taux     , rc=rc)
+    call dshr_state_getfldptr(exportState, 'Faii_taux'     , fldptr1=Faii_taux     , allowNullReturn=.true., rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faii_tauy'     , fldptr1=Faii_tauy     , allowNullReturn=.true., rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/dice/dice_datamode_cplhist_mod.F90
+++ b/dice/dice_datamode_cplhist_mod.F90
@@ -22,6 +22,7 @@ module dice_datamode_cplhist_mod
   ! export fields
   ! ice to atm in CMEPS/mediator/esmFldsExchange_ufs_mod.F90
   real(r8), pointer :: Si_ifrac(:)  => null()
+  real(r8), pointer :: Si_imask(:)  => null()
   real(r8), pointer :: Faii_taux(:)      => null()
   real(r8), pointer :: Faii_tauy(:)      => null()
   real(r8), pointer :: Faii_lat(:)      => null()
@@ -62,6 +63,7 @@ contains
     ! Advertise export fields
     call dshr_fldList_add(fldsExport, trim(flds_scalar_name))
     call dshr_fldList_add(fldsExport, 'Si_ifrac'            )
+    call dshr_fldList_add(fldsExport, 'Si_imask'            )
     call dshr_fldList_add(fldsExport, 'Faii_taux'           )
     call dshr_fldList_add(fldsExport, 'Faii_tauy'           )
     call dshr_fldList_add(fldsExport, 'Faii_lat'            )
@@ -103,6 +105,8 @@ contains
 
     ! initialize pointers to export fields
     call dshr_state_getfldptr(exportState, 'Si_ifrac' , fldptr1=Si_ifrac , rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Si_imask' , fldptr1=Si_imask , rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faii_taux'     , fldptr1=Faii_taux     , rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/dice/dice_datamode_cplhist_mod.F90
+++ b/dice/dice_datamode_cplhist_mod.F90
@@ -1,0 +1,189 @@
+module dice_datamode_cplhist_mod
+
+  use ESMF             , only : ESMF_State, ESMF_LOGMSG_INFO, ESMF_LogWrite, ESMF_SUCCESS
+  use NUOPC            , only : NUOPC_Advertise
+  use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
+  !use shr_const_mod    , only : shr_const_TkFrz, shr_const_pi, shr_const_ocn_ref_sal
+  use shr_sys_mod      , only : shr_sys_abort
+  use dshr_methods_mod , only : dshr_state_getfldptr, dshr_fldbun_getfldptr, chkerr
+  use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
+  use dshr_mod         , only : dshr_restart_read, dshr_restart_write
+  use dshr_strdata_mod , only : shr_strdata_type
+
+  implicit none
+  private ! except
+
+  public  :: dice_datamode_cplhist_advertise
+  public  :: dice_datamode_cplhist_init_pointers
+  public  :: dice_datamode_cplhist_advance
+  public  :: dice_datamode_cplhist_restart_read
+  public  :: dice_datamode_cplhist_restart_write
+
+  ! export fields
+  ! ice to atm in CMEPS/mediator/esmFldsExchange_ufs_mod.F90
+  real(r8), pointer :: Si_ifrac(:)  => null()
+  real(r8), pointer :: Faii_taux(:)      => null()
+  real(r8), pointer :: Faii_tauy(:)      => null()
+  real(r8), pointer :: Faii_lat(:)      => null()
+  real(r8), pointer :: Faii_sen(:)      => null()
+  real(r8), pointer :: Faii_lwup(:)      => null()
+  real(r8), pointer :: Faii_evap(:)      => null()
+  real(r8), pointer :: Si_vice(:)      => null()
+  real(r8), pointer :: Si_vsno(:) => null()
+  real(r8), pointer :: Si_t(:)      => null()
+  real(r8), pointer :: Si_avsdr(:)      => null()
+  real(r8), pointer :: Si_avsdf(:)      => null()
+  real(r8), pointer :: Si_anidr(:)      => null()
+  real(r8), pointer :: Si_anidf(:)      => null()
+
+  character(*) , parameter :: nullstr = 'null'
+  character(*) , parameter :: rpfile  = 'rpointer.ice'
+  character(*) , parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine dice_datamode_cplhist_advertise(exportState, fldsexport, flds_scalar_name, rc)
+
+    ! input/output variables
+    type(esmf_State)   , intent(inout) :: exportState
+    type(fldlist_type) , pointer       :: fldsexport
+    character(len=*)   , intent(in)    :: flds_scalar_name
+    integer            , intent(out)   :: rc
+
+    ! local variables
+    type(fldlist_type), pointer :: fldList
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Advertise export fields
+    call dshr_fldList_add(fldsExport, trim(flds_scalar_name))
+    call dshr_fldList_add(fldsExport, 'Si_ifrac'            )
+    call dshr_fldList_add(fldsExport, 'Faii_taux'           )
+    call dshr_fldList_add(fldsExport, 'Faii_tauy'           )
+    call dshr_fldList_add(fldsExport, 'Faii_lat'            )
+    call dshr_fldList_add(fldsExport, 'Faii_sen'            )
+    call dshr_fldList_add(fldsExport, 'Faii_lwup'           )
+    call dshr_fldList_add(fldsExport, 'Faii_evap'           )
+    call dshr_fldList_add(fldsExport, 'Si_vice'             )
+    call dshr_fldList_add(fldsExport, 'Si_vsno'             )
+    call dshr_fldList_add(fldsExport, 'Si_t'                )
+    call dshr_fldList_add(fldsExport, 'Si_avsdr'            )
+    call dshr_fldList_add(fldsExport, 'Si_avsdf'            )
+    call dshr_fldList_add(fldsExport, 'Si_anidr'            )
+    call dshr_fldList_add(fldsExport, 'Si_anidf'            )
+
+    fldlist => fldsExport ! the head of the linked list
+    do while (associated(fldlist))
+       call NUOPC_Advertise(exportState, standardName=fldlist%stdname, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_LogWrite('(dice_comp_advertise): Fr_ocn'//trim(fldList%stdname), ESMF_LOGMSG_INFO)
+       fldList => fldList%next
+    enddo
+
+  end subroutine dice_datamode_cplhist_advertise
+
+  !===============================================================================
+  subroutine dice_datamode_cplhist_init_pointers(importState, exportState,sdat,rc)
+
+    ! input/output variables
+    type(ESMF_State)       , intent(inout) :: importState
+    type(ESMF_State)       , intent(inout) :: exportState
+    type(shr_strdata_type) , intent(in)    :: sdat
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    character(len=*), parameter :: subname='(dice_init_pointers): '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! initialize pointers to export fields
+    call dshr_state_getfldptr(exportState, 'Si_ifrac' , fldptr1=Si_ifrac , rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faii_taux'     , fldptr1=Faii_taux     , rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faii_tauy'     , fldptr1=Faii_tauy     , allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faii_lat'     , fldptr1=Faii_lat     , allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faii_sen', fldptr1=Faii_sen, allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faii_lwup', fldptr1=Faii_lwup, allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faii_evap', fldptr1=Faii_evap, allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Si_vice', fldptr1=Si_vice, allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Si_vsno', fldptr1=Si_vsno, allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Si_t', fldptr1=Si_t, allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Si_avsdr', fldptr1=Si_avsdr, allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Si_avsdf', fldptr1=Si_avsdf, allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Si_anidr', fldptr1=Si_anidr, allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Si_anidf', fldptr1=Si_anidf, allowNullReturn=.true., rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    !Initialize (e.g., =0)?
+
+  end subroutine dice_datamode_cplhist_init_pointers
+
+  !===============================================================================
+  subroutine dice_datamode_cplhist_advance(rc)
+
+    ! input/output variables
+    integer, intent(out)   :: rc
+
+    ! local variables
+    character(len=*), parameter :: subname='(dice_datamode_cplhist_advance): '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! For now - do nothing special
+
+  end subroutine dice_datamode_cplhist_advance
+
+  !===============================================================================
+  subroutine dice_datamode_cplhist_restart_write(case_name, inst_suffix, ymd, tod, &
+       logunit, my_task, sdat)
+
+    ! input/output variables
+    character(len=*)            , intent(in)    :: case_name
+    character(len=*)            , intent(in)    :: inst_suffix
+    integer                     , intent(in)    :: ymd       ! model date
+    integer                     , intent(in)    :: tod       ! model sec into model date
+    integer                     , intent(in)    :: logunit
+    integer                     , intent(in)    :: my_task
+    type(shr_strdata_type)      , intent(inout) :: sdat
+    !-------------------------------------------------------------------------------
+
+    call dshr_restart_write(rpfile, case_name, 'dice', inst_suffix, ymd, tod, &
+         logunit, my_task, sdat)
+
+  end subroutine dice_datamode_cplhist_restart_write
+
+  !===============================================================================
+  subroutine dice_datamode_cplhist_restart_read(rest_filem, inst_suffix, logunit, my_task, mpicom, sdat)
+
+    ! input/output arguments
+    character(len=*)            , intent(inout) :: rest_filem
+    character(len=*)            , intent(in)    :: inst_suffix
+    integer                     , intent(in)    :: logunit
+    integer                     , intent(in)    :: my_task
+    integer                     , intent(in)    :: mpicom
+    type(shr_strdata_type)      , intent(inout) :: sdat
+    !-------------------------------------------------------------------------------
+
+    call dshr_restart_read(rest_filem, rpfile, inst_suffix, nullstr, logunit, my_task, mpicom, sdat)
+
+  end subroutine dice_datamode_cplhist_restart_read
+
+end module dice_datamode_cplhist_mod

--- a/dice/dice_datamode_cplhist_mod.F90
+++ b/dice/dice_datamode_cplhist_mod.F90
@@ -80,7 +80,7 @@ contains
     do while (associated(fldlist))
        call NUOPC_Advertise(exportState, standardName=fldlist%stdname, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call ESMF_LogWrite('(dice_comp_advertise): Fr_ocn'//trim(fldList%stdname), ESMF_LOGMSG_INFO)
+       call ESMF_LogWrite('(dice_comp_advertise): Fr_ice'//trim(fldList%stdname), ESMF_LOGMSG_INFO)
        fldList => fldList%next
     enddo
 

--- a/dice/ice_comp_nuopc.F90
+++ b/dice/ice_comp_nuopc.F90
@@ -16,7 +16,7 @@ module cdeps_dice_comp
   use ESMF                 , only : ESMF_AlarmIsRinging, ESMF_METHOD_INITIALIZE
   use ESMF                 , only : ESMF_ClockGet, ESMF_TimeGet, ESMF_MethodRemove, ESMF_MethodAdd
   use ESMF                 , only : ESMF_GridCompSetEntryPoint, operator(+), ESMF_AlarmRingerOff
-  use ESMF                 , only : ESMF_ClockGetAlarm, ESMF_StateGet, ESMF_Field, ESMF_FieldGet
+  use ESMF                 , only : ESMF_ClockGetAlarm, ESMF_StateGet, ESMF_Field, ESMF_FieldGet, ESMF_MAXSTR
   use NUOPC                , only : NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
   use NUOPC                , only : NUOPC_CompAttributeGet, NUOPC_Advertise
   use NUOPC_Model          , only : model_routine_SS        => SetServices
@@ -503,11 +503,15 @@ contains
     if (first_time) then
 
        ! Initialize dfields with export state data that has corresponding stream fieldi
-       if ( trim(datamode) == 'ssmi' .or. trim(datamode) == 'ssmi_iaf') then
-       call dshr_dfield_add(dfields, sdat, state_fld='Si_ifrac', strm_fld='Si_ifrac', &
+       select case (trim(datamode))
+       case('ssmi','ssmi_iaf')
+         call dshr_dfield_add(dfields, sdat, state_fld='Si_ifrac', strm_fld='Si_ifrac', &
             state=exportState, logunit=logunit, mainproc=mainproc, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       end if
+         if (chkerr(rc,__LINE__,u_FILE_u)) return
+       case('cplhist')
+         call dice_init_dfields(importState, exportState, rc)
+         if (chkerr(rc,__LINE__,u_FILE_u)) return
+       end select
 
        ! Initialize datamode module ponters
        select case (trim(datamode))
@@ -593,6 +597,46 @@ contains
 
     call ESMF_TraceRegionExit('dice_datamode')
     call ESMF_TraceRegionExit('DICE_RUN')
+
+  contains
+    subroutine dice_init_dfields(importState, exportState, rc)
+      ! -----------------------------
+      ! Initialize dfields arrays
+      ! -----------------------------
+
+      ! input/output variables
+      type(ESMF_State)       , intent(inout) :: importState
+      type(ESMF_State)       , intent(inout) :: exportState
+      integer                , intent(out)   :: rc
+
+      ! local variables
+      integer                         :: n
+      integer                         :: fieldcount
+      type(ESMF_Field)                :: lfield
+      character(ESMF_MAXSTR) ,pointer :: lfieldnamelist(:)
+      character(*), parameter   :: subName = "(dice_init_dfields) "
+      !-------------------------------------------------------------------------------
+
+      rc = ESMF_SUCCESS
+
+      ! Initialize dfields data type (to map streams to export state fields)
+      ! Create dfields linked list - used for copying stream fields to export
+      ! state fields
+      call ESMF_StateGet(exportState, itemCount=fieldCount, rc=rc)
+      if (chkerr(rc,__LINE__,u_FILE_u)) return
+      allocate(lfieldnamelist(fieldCount))
+      call ESMF_StateGet(exportState, itemNameList=lfieldnamelist, rc=rc)
+      if (chkerr(rc,__LINE__,u_FILE_u)) return
+      do n = 1, fieldCount
+         call ESMF_StateGet(exportState, itemName=trim(lfieldNameList(n)), field=lfield, rc=rc)
+         if (chkerr(rc,__LINE__,u_FILE_u)) return
+         if (trim(lfieldnamelist(n)) /= flds_scalar_name) then
+            call dshr_dfield_add( dfields, sdat, trim(lfieldnamelist(n)), trim(lfieldnamelist(n)), exportState, &
+                 logunit, mainproc, rc)
+            if (chkerr(rc,__LINE__,u_FILE_u)) return
+         end if
+      end do
+    end subroutine dice_init_dfields
 
   end subroutine dice_comp_run
 

--- a/dice/ice_comp_nuopc.F90
+++ b/dice/ice_comp_nuopc.F90
@@ -182,6 +182,7 @@ contains
     integer           :: bcasttmp(4)
     real(r8)          :: rbcasttmp(3)
     type(ESMF_VM)     :: vm
+    logical           :: isPresent, isSet
     character(len=*),parameter  :: subname=trim(modName)//':(InitializeAdvertise) '
     character(*)    ,parameter :: F00 = "('(" // trim(modName) // ") ',8a)"
     character(*)    ,parameter :: F01 = "('(" // trim(modName) // ") ',a,2x,i8)"
@@ -279,9 +280,11 @@ contains
     endif
 
     ! Advertise import and export fields
-    call NUOPC_CompAttributeGet(gcomp, name='flds_i2o_per_cat', value=cvalue, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    read(cvalue,*) flds_i2o_per_cat  ! module variable
+    if ( trim(datamode) == 'ssmi' .or. trim(datamode) == 'ssmi_iaf') then 
+      call NUOPC_CompAttributeGet(gcomp, name='flds_i2o_per_cat', value=cvalue, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      if (isPresent .and. isSet) read(cvalue,*) flds_i2o_per_cat  ! module variable
+    endif
 
     !datamode already validated
     select case (trim(datamode))

--- a/dice/ice_comp_nuopc.F90
+++ b/dice/ice_comp_nuopc.F90
@@ -41,6 +41,12 @@ module cdeps_dice_comp
   use dice_datamode_ssmi_mod , only : dice_datamode_ssmi_advance
   use dice_datamode_ssmi_mod , only : dice_datamode_ssmi_restart_read
   use dice_datamode_ssmi_mod , only : dice_datamode_ssmi_restart_write
+  !
+  use dice_datamode_cplhist_mod , only : dice_datamode_cplhist_advertise
+  use dice_datamode_cplhist_mod , only : dice_datamode_cplhist_init_pointers
+  use dice_datamode_cplhist_mod , only : dice_datamode_cplhist_advance
+  use dice_datamode_cplhist_mod , only : dice_datamode_cplhist_restart_read
+  use dice_datamode_cplhist_mod , only : dice_datamode_cplhist_restart_write
 
   implicit none
   private ! except
@@ -266,7 +272,7 @@ contains
     flux_Qacc0 = rbcasttmp(3)
 
     ! Validate datamode
-    if ( trim(datamode) == 'ssmi' .or. trim(datamode) == 'ssmi_iaf') then
+    if ( trim(datamode) == 'ssmi' .or. trim(datamode) == 'ssmi_iaf' or trim(datamode) == 'cplhist') then
        if (my_task == main_task) write(logunit,*) ' dice datamode = ',trim(datamode)
     else
        call shr_sys_abort(' ERROR illegal dice datamode = '//trim(datamode))
@@ -277,9 +283,14 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     read(cvalue,*) flds_i2o_per_cat  ! module variable
 
+    !datamode already validated
     select case (trim(datamode))
-    case('ssmi', 'ssmi_iaf')
+    case('ssmi','ssmi_iaf')
        call dice_datamode_ssmi_advertise(importState, exportState, fldsimport, fldsexport, &
+            flds_scalar_name, flds_i2o_per_cat, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    case('cplhist')
+       call dice_datamode_cplhist_advertise(importState, exportState, fldsimport, fldsexport, &
             flds_scalar_name, flds_i2o_per_cat, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end select
@@ -489,15 +500,20 @@ contains
 
     if (first_time) then
 
-       ! Initialize dfields with export state data that has corresponding stream field
+       ! Initialize dfields with export state data that has corresponding stream fieldi
+       if ( trim(datamode) == 'ssmi' .or. trim(datamode) == 'ssmi_iaf') then
        call dshr_dfield_add(dfields, sdat, state_fld='Si_ifrac', strm_fld='Si_ifrac', &
             state=exportState, logunit=logunit, mainproc=mainproc, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
+       end if
 
        ! Initialize datamode module ponters
        select case (trim(datamode))
        case('ssmi', 'ssmi_iaf')
           call dice_datamode_ssmi_init_pointers(importState, exportState, sdat, flds_i2o_per_cat, rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+       case('cplhist')
+          call dice_datamode_cplhist_init_pointers(importState,exportState,sdat,rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        end select
 
@@ -506,6 +522,8 @@ contains
           select case (trim(datamode))
           case('ssmi', 'ssmi_iaf')
              call dice_datamode_ssmi_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat)
+          case('cplhist')
+             call dice_datamode_cplhist_restart_read(rest_filem, inst_suffix, logunit, my_task, mpicom, sdat) 
           end select
        end if
 
@@ -546,14 +564,21 @@ contains
        call dice_datamode_ssmi_advance(exportState, importState, cosarg, flds_i2o_per_cat, &
             flux_swpf, flux_Qmin, flux_Qacc, flux_Qacc0, dt, logunit, restart_read, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    case ('cplhist')
+       call dice_datamode_cplhist_advance(rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return 
     end select
 
     ! Write restarts if needed
+    ! TODO - no rc returned
     if (restart_write) then
        select case (trim(datamode))
        case('ssmi', 'ssmi_iaf')
           call dice_datamode_ssmi_restart_write(case_name, inst_suffix, target_ymd, target_tod, &
                logunit, my_task, sdat)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       case ('cplhist')
+          call dice_datamode_cplhist_restart_write(case_name, inst_suffix, ymd, tod, logunit, my_task, sdat)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end select
     end if

--- a/dice/ice_comp_nuopc.F90
+++ b/dice/ice_comp_nuopc.F90
@@ -272,7 +272,7 @@ contains
     flux_Qacc0 = rbcasttmp(3)
 
     ! Validate datamode
-    if ( trim(datamode) == 'ssmi' .or. trim(datamode) == 'ssmi_iaf' or trim(datamode) == 'cplhist') then
+    if ( trim(datamode) == 'ssmi' .or. trim(datamode) == 'ssmi_iaf' .or. trim(datamode) == 'cplhist') then
        if (my_task == main_task) write(logunit,*) ' dice datamode = ',trim(datamode)
     else
        call shr_sys_abort(' ERROR illegal dice datamode = '//trim(datamode))
@@ -290,8 +290,7 @@ contains
             flds_scalar_name, flds_i2o_per_cat, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case('cplhist')
-       call dice_datamode_cplhist_advertise(importState, exportState, fldsimport, fldsexport, &
-            flds_scalar_name, flds_i2o_per_cat, rc)
+       call dice_datamode_cplhist_advertise(exportState, fldsexport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end select
 
@@ -523,7 +522,7 @@ contains
           case('ssmi', 'ssmi_iaf')
              call dice_datamode_ssmi_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat)
           case('cplhist')
-             call dice_datamode_cplhist_restart_read(rest_filem, inst_suffix, logunit, my_task, mpicom, sdat) 
+             call dice_datamode_cplhist_restart_read(restfilm, inst_suffix, logunit, my_task, mpicom, sdat) 
           end select
        end if
 
@@ -578,7 +577,7 @@ contains
                logunit, my_task, sdat)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case ('cplhist')
-          call dice_datamode_cplhist_restart_write(case_name, inst_suffix, ymd, tod, logunit, my_task, sdat)
+          call dice_datamode_cplhist_restart_write(case_name, inst_suffix, target_ymd, target_tod, logunit, my_task, sdat)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end select
     end if

--- a/doc/source/dice.rst
+++ b/doc/source/dice.rst
@@ -27,6 +27,9 @@ ssmi (``dice_datamode_ssmi_mod.F90``)
 ssmi_iaf (``dice_datamode_ssmi_mod.F90``)
   - `ssmi_iaf` is the interannually varying version of `ssmi`.
 
+cplhist (``dice_datamode_cplhist_mod.F90``)
+  - It provides mediator history variables from ice component of previous simulation.
+
 .. _dice-cime-vars:
 
 ---------------------------------------

--- a/docn/docn_datamode_cplhist_mod.F90
+++ b/docn/docn_datamode_cplhist_mod.F90
@@ -96,10 +96,11 @@ contains
     call dshr_state_getfldptr(exportState, 'So_bldepth', fldptr1=So_bldepth, allowNullReturn=.true., rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    So_u(:) = 0.0_r8
-    So_v(:) = 0.0_r8
-    So_t(:) = TkFrz
-    So_bldepth(:) = 0.0_r8
+    !Allocation depends on exchanged fields, so check before filling arrays with values here
+    if (associated(So_u)) So_u(:) = 0.0_r8
+    if (associated(So_v)) So_v(:) = 0.0_r8
+    if (associated(So_t)) So_t(:) = TkFrz
+    if (associated(So_bldepth)) So_bldepth(:) = 0.0_r8
 
     ! Set export state ocean fraction (So_omask)
     So_omask(:) = ocn_fraction(:)
@@ -107,9 +108,10 @@ contains
   end subroutine docn_datamode_cplhist_init_pointers
 
   !===============================================================================
-  subroutine docn_datamode_cplhist_advance(rc)
+  subroutine docn_datamode_cplhist_advance(sst_constant_value, rc)
 
     ! input/output variables
+    real(r8), optional, intent(in) :: sst_constant_value
     integer, intent(out)   :: rc
 
     ! local variables
@@ -118,9 +120,14 @@ contains
 
     rc = ESMF_SUCCESS
 
-    !If need unit conversion for So_t (C-->K)
-    if (minval(So_t) .LT. 100.0_r8) then !Assume input SST in Celsius
-      So_t(:) = So_t(:) + TkFrz
+    !If need unit conversion for So_t (C-->K),
+    !use existing nml variable sst_constant_value to signal units of input
+    !i.e., 0-->Celsius, 273.15-->K
+    
+    if (present(sst_constant_value)) then
+      if(sst_constant_value .LT. 10.0_r8) then !Assume input SST in Celsius
+        So_t(:) = So_t(:) + TkFrz
+      endif
     endif
 
   end subroutine docn_datamode_cplhist_advance

--- a/docn/docn_datamode_cplhist_mod.F90
+++ b/docn/docn_datamode_cplhist_mod.F90
@@ -119,7 +119,9 @@ contains
     rc = ESMF_SUCCESS
 
     !If need unit conversion for So_t (C-->K)
-    !So_t(:) = So_t(:) + TkFrz
+    if (minval(So_t) .LT. 100.0_r8) then !Assume input SST in Celsius
+      So_t(:) = So_t(:) + TkFrz
+    endif
 
   end subroutine docn_datamode_cplhist_advance
 

--- a/docn/docn_datamode_cplhist_mod.F90
+++ b/docn/docn_datamode_cplhist_mod.F90
@@ -115,6 +115,7 @@ contains
     integer, intent(out)   :: rc
 
     ! local variables
+    logical                     :: units_CToK = .true. ! true => convert SST in C to K
     character(len=*), parameter :: subname='(docn_datamode_cplhist_advance): '
     !-------------------------------------------------------------------------------
 
@@ -125,9 +126,13 @@ contains
     !i.e., 0-->Celsius, 273.15-->K
     
     if (present(sst_constant_value)) then
-      if(sst_constant_value .LT. 10.0_r8) then !Assume input SST in Celsius
-        So_t(:) = So_t(:) + TkFrz
+      if(sst_constant_value .GT. 230.0_r8) then !interpret input SST in K
+        units_CToK = .false. !in K already, don't convert
       endif
+    endif
+
+    if (units_CToK) then
+      So_t(:) = So_t(:) + TkFrz
     endif
 
   end subroutine docn_datamode_cplhist_advance

--- a/docn/docn_datamode_cplhist_mod.F90
+++ b/docn/docn_datamode_cplhist_mod.F90
@@ -118,7 +118,8 @@ contains
 
     rc = ESMF_SUCCESS
 
-    So_t(:) = So_t(:) + TkFrz
+    !If need unit conversion for So_t (C-->K)
+    !So_t(:) = So_t(:) + TkFrz
 
   end subroutine docn_datamode_cplhist_advance
 

--- a/docn/ocn_comp_nuopc.F90
+++ b/docn/ocn_comp_nuopc.F90
@@ -605,7 +605,7 @@ contains
        call  docn_datamode_aquaplanet_advance(exportState, model_mesh, sst_constant_value=sst_constant_value, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case('cplhist')
-       call  docn_datamode_cplhist_advance(rc=rc)
+       call  docn_datamode_cplhist_advance(sst_constant_value=sst_constant_value, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end select
 


### PR DESCRIPTION
### Description of changes
A new dice_datamode_cplhist_mod is adapted from docn_datamode_cplhist_mod. 
Existing sst_constant_value namelist value is used in docn_datamode_cplhist_advance to handle SST units in K and C.

### Specific notes

Contributors other than yourself, if any:

CDEPS Issues Fixed (include github issue #): https://github.com/NOAA-EMC/CDEPS/issues/61

Are there dependencies on other component PRs (if so list):

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb for existing and new for new datamode

Any User Interface Changes (namelist or namelist defaults changes):

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): UFS regression testing (https://github.com/ufs-community/ufs-weather-model/pull/2186)

Hashes used for testing: See https://github.com/ufs-community/ufs-weather-model/pull/2186

